### PR TITLE
fix: improve PIN sequence detection

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -106,27 +106,23 @@ export const validatePinSecurity = (pin) => {
     errors.push('PIN cannot be all the same digit')
   }
 
-  // Check for sequential ascending patterns (1234, 5678, 0123, etc.)
+  // Check for sequential ascending or descending patterns (1234, 6789, 4321, 2109, etc.)
   const digits = pin.split('').map(Number)
-  let isSequentialAsc = true
-  for (let i = 1; i < digits.length; i++) {
-    if (digits[i] !== digits[i-1] + 1) {
-      isSequentialAsc = false
-      break
-    }
-  }
+
+  // Ascending sequence with wrap-around (e.g. 7890)
+  const isSequentialAsc = digits.every((digit, i) => {
+    if (i === 0) return true
+    return digit === (digits[i - 1] + 1) % 10
+  })
   if (isSequentialAsc) {
     errors.push('PIN cannot be sequential numbers')
   }
 
-  // Check for sequential descending patterns (4321, 8765, etc.)
-  let isSequentialDesc = true
-  for (let i = 1; i < digits.length; i++) {
-    if (digits[i] !== digits[i-1] - 1) {
-      isSequentialDesc = false
-      break
-    }
-  }
+  // Descending sequence with wrap-around (e.g. 2109)
+  const isSequentialDesc = digits.every((digit, i) => {
+    if (i === 0) return true
+    return digit === (digits[i - 1] + 9) % 10 // equivalent to (prev - 1 + 10) % 10
+  })
   if (isSequentialDesc) {
     errors.push('PIN cannot be sequential numbers')
   }
@@ -134,8 +130,8 @@ export const validatePinSecurity = (pin) => {
   // Check for common weak patterns
   const weakPatterns = [
     '0000', '1111', '2222', '3333', '4444', '5555', '6666', '7777', '8888', '9999', // repeated
-    '1234', '2345', '3456', '4567', '5678', '6789', '0123', // ascending
-    '9876', '8765', '7654', '6543', '5432', '4321', '3210', '9210', // descending
+    '1234', '2345', '3456', '4567', '5678', '6789', '7890', '8901', '9012', '0123', // ascending
+    '9876', '8765', '7654', '6543', '5432', '4321', '3210', '2109', '1098', '0987', // descending
     '1010', '2020', '1212', '2121', '3030', '4040', '5050', // alternating
     '0101', '1313', '2424', '3535', '4646', '5757', '6868', '7979', '8080', '9191' // alternating
   ]


### PR DESCRIPTION
## Summary
- handle wrap-around ascending and descending PIN sequences
- expand weak PIN pattern list

## Testing
- `npm test` *(fails: browsers missing)*
- `npx playwright install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68ae6b6919bc8326a0b1da85c9107f1a